### PR TITLE
Add admin redirect and improve admin template for plugin

### DIFF
--- a/lib/controllers/admin.js
+++ b/lib/controllers/admin.js
@@ -7,5 +7,7 @@ adminControllers.renderAdminPage = function (req, res) {
 };
 
 adminControllers.redirectToLogin = function (req, res) {
+	req.session.returnTo = '/admin';
+	req.session.save();
 	res.redirect('/login?isAdmin=true');
 };

--- a/lib/controllers/admin.js
+++ b/lib/controllers/admin.js
@@ -5,9 +5,3 @@ var adminControllers = module.exports;
 adminControllers.renderAdminPage = function (req, res) {
 	res.render('admin/plugins/openedx-discussion', {});
 };
-
-adminControllers.redirectToLogin = function (req, res) {
-	req.session.returnTo = '/admin';
-	req.session.save();
-	res.redirect('/login?isAdmin=true');
-};

--- a/library.js
+++ b/library.js
@@ -20,9 +20,6 @@ plugin.init = function (params, callback) {
 	router.get('/embed', hostMiddleware.buildHeader, controllers.embed.embedView);
 	router.get('/api/embed', controllers.embed.embedView);
 
-	router.get('/adminlogin', hostMiddleware.buildHeader, controllers.adminPanel.redirectToLogin);
-	router.get('/api/adminlogin', controllers.adminPanel.redirectToLogin);
-
 	callback();
 };
 
@@ -64,7 +61,8 @@ plugin.authenticateSession = function (req, res, callback) {
 			});
 		}
 
-		if (req.path === '/login' && settings.loginURL && !req.query.isAdmin) {
+
+		if (req.path === '/login' && settings.loginURL && req.session.returnTo !== '/admin') {
 			return res.redirect(settings.loginURL);
 		} else if (req.path === '/register' && settings.registrationURL) {
 			return res.redirect(settings.registrationURL);

--- a/static/templates/admin/plugins/openedx-discussion.tpl
+++ b/static/templates/admin/plugins/openedx-discussion.tpl
@@ -5,10 +5,6 @@
 			<p class="lead">
 				Configure these settings to share session between openEdx and nodebb instance.
 			</p>
-			<p>
-			<bold>Note:</bold> <span>When this plugin is activated and value for <code>Redirect Login Url</code> is set, login page of admin panel will be accessed from url: <code>/adminlogin</code></span>
-			</p>
-
 			<div class="row panel panel-body">
 				<div class="form-group">
 					<label for="jwtCookieName">JWT cookie name</label>

--- a/static/templates/admin/plugins/openedx-discussion.tpl
+++ b/static/templates/admin/plugins/openedx-discussion.tpl
@@ -4,42 +4,64 @@
 		<div class="col-sm-10 col-xs-12">
 			<p class="lead">
 				Configure these settings to share session between openEdx and nodebb instance.
-
-				JWT Cookie Name: Name of the encoded jwt cookie that will be sent with requests to nodebb.
-				Secret: `key` for "key:value" pair of secret used for jwt encoding and decoding.
-				Redirect Login Url: `login-url` for where to direct an user when he tries to login.
-				Redirect Registration Url: `registration-url` for where to direct an user when he tries to register.
-				Logout Url: `logout-url` is the openedx logout url which will be used to clear session when user logs out from nodebb.
 			</p>
 
-			<div class="form-group">
-				<label for="jwtCookieNamee">JWT cookie name</label>
-				<input type="text" id="jwtCookieName" name="jwtCookieName" title="JWT Cookie Name" class="form-control" placeholder="Token">
+			<div class="row panel panel-body">
+				<div class="form-group">
+					<label for="jwtCookieName">JWT cookie name</label>
+					<input type="text" id="jwtCookieName" name="jwtCookieName" title="JWT Cookie Name"
+						class="form-control" placeholder="Token">
+				</div>
+				<p>JWT Cookie Name: Name of the encoded jwt cookie that will be sent with requests to nodebb.</p>
+
 			</div>
 
-			<div class="form-group">
-				<label for="secret">Secret</label>
-				<input type="text" id="secret" name="secret" title="secret" class="secret" placeholder="its a secret">
+			<div class="row panel panel-body">
+				<div class="form-group">
+					<label for="secret">Secret</label>
+					<input type="text" id="secret" name="secret" title="secret" class="form-control"
+						placeholder="its a secret">
+					<p>Secret: `key` for "key:value" pair of secret used for jwt encoding and decoding.</p>
+				</div>
 			</div>
 
-			<div class="form-group">
-				<label for="loginURL">Login URL</label>
-				<input type="text" id="loginURL" name="loginURL" title="loginURL" class="loginURL" placeholder="https://example.com/login">
+			<div class="row panel panel-body">
+				<div class="form-group">
+					<label for="loginURL">Login URL</label>
+					<input type="text" id="loginURL" name="loginURL" title="loginURL" class="form-control"
+						placeholder="https://example.com/login">
+					<p>Redirect Login Url: `login-url` for where to direct an user when he tries to login.</p>
+
+				</div>
 			</div>
 
-			<div class="form-group">
-				<label for="registrationURL">Registration URL</label>
-				<input type="text" id="registrationURL" name="registrationURL" title="registrationURL" class="registrationURL" placeholder="https://example.com/register">
+			<div class="row panel panel-body">
+				<div class="form-group">
+					<label for="registrationURL">Registration URL</label>
+					<input type="text" id="registrationURL" name="registrationURL" title="registrationURL"
+						class="form-control" placeholder="https://example.com/register">
+					<p>Redirect Registration Url: `registration-url` for where to direct an user when he tries to
+						register.</p>
+
+				</div>
 			</div>
 
-			<div class="form-group">
-				<label for="logoutURL">Logout redirect URL</label>
-				<input type="text" id="logoutURL" name="logoutURL" title="logoutURL" class="logoutURL" placeholder="https://example.com/logout">
+			<div class="row panel panel-body">
+				<div class="form-group">
+					<label for="logoutURL">Logout redirect URL</label>
+					<input type="text" id="logoutURL" name="logoutURL" title="logoutURL" class="form-control"
+						placeholder="https://example.com/logout">
+					<p>Logout Url: `logout-url` is the openedx logout url which will be used to clear session when user
+						logs out from nodebb.</p>
+
+				</div>
+
 			</div>
 		</div>
 	</div>
 </form>
 
-<button id="save" class="floating-button mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-button--colored">
+<button id="save"
+	class="floating-button mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-button--colored">
 	<i class="material-icons">save</i>
 </button>

--- a/static/templates/admin/plugins/openedx-discussion.tpl
+++ b/static/templates/admin/plugins/openedx-discussion.tpl
@@ -5,6 +5,9 @@
 			<p class="lead">
 				Configure these settings to share session between openEdx and nodebb instance.
 			</p>
+			<p>
+			<bold>Note:</bold> <span>When this plugin is activated and value for <code>Redirect Login Url</code> is set, login page of admin panel will be accessed from url: <code>/adminlogin</code></span>
+			</p>
 
 			<div class="row panel panel-body">
 				<div class="form-group">
@@ -12,7 +15,7 @@
 					<input type="text" id="jwtCookieName" name="jwtCookieName" title="JWT Cookie Name"
 						class="form-control" placeholder="Token">
 				</div>
-				<p>JWT Cookie Name: Name of the encoded jwt cookie that will be sent with requests to nodebb.</p>
+				<p><code>JWT Cookie Name</code> Name of the encoded jwt cookie that will be sent with requests to nodebb.</p>
 
 			</div>
 
@@ -21,7 +24,7 @@
 					<label for="secret">Secret</label>
 					<input type="text" id="secret" name="secret" title="secret" class="form-control"
 						placeholder="its a secret">
-					<p>Secret: `key` for "key:value" pair of secret used for jwt encoding and decoding.</p>
+					<p><code>Secret</code> "key" for "key:value" pair of secret used for jwt encoding and decoding.</p>
 				</div>
 			</div>
 
@@ -30,7 +33,7 @@
 					<label for="loginURL">Login URL</label>
 					<input type="text" id="loginURL" name="loginURL" title="loginURL" class="form-control"
 						placeholder="https://example.com/login">
-					<p>Redirect Login Url: `login-url` for where to direct an user when he tries to login.</p>
+					<p><code>Redirect Login Url</code> `login-url` for where to direct an user when he tries to login.</p>
 
 				</div>
 			</div>
@@ -40,7 +43,7 @@
 					<label for="registrationURL">Registration URL</label>
 					<input type="text" id="registrationURL" name="registrationURL" title="registrationURL"
 						class="form-control" placeholder="https://example.com/register">
-					<p>Redirect Registration Url: `registration-url` for where to direct an user when he tries to
+					<p><code>Redirect Registration Url</code> `registration-url` for where to direct an user when he tries to
 						register.</p>
 
 				</div>
@@ -51,7 +54,7 @@
 					<label for="logoutURL">Logout redirect URL</label>
 					<input type="text" id="logoutURL" name="logoutURL" title="logoutURL" class="form-control"
 						placeholder="https://example.com/logout">
-					<p>Logout Url: `logout-url` is the openedx logout url which will be used to clear session when user
+					<p><code>Logout Url</code> `logout-url` is the openedx logout url which will be used to clear session when user
 						logs out from nodebb.</p>
 
 				</div>

--- a/static/templates/admin/plugins/openedx-discussion.tpl
+++ b/static/templates/admin/plugins/openedx-discussion.tpl
@@ -31,7 +31,7 @@
 			<div class="row panel panel-body">
 				<div class="form-group">
 					<label for="loginURL">Login URL</label>
-					<input type="text" id="loginURL" name="loginURL" title="loginURL" class="form-control"
+					<input type="url" id="loginURL" name="loginURL" title="loginURL" class="form-control"
 						placeholder="https://example.com/login">
 					<p><code>Redirect Login Url</code> `login-url` for where to direct an user when he tries to login.</p>
 
@@ -41,7 +41,7 @@
 			<div class="row panel panel-body">
 				<div class="form-group">
 					<label for="registrationURL">Registration URL</label>
-					<input type="text" id="registrationURL" name="registrationURL" title="registrationURL"
+					<input type="url" id="registrationURL" name="registrationURL" title="registrationURL"
 						class="form-control" placeholder="https://example.com/register">
 					<p><code>Redirect Registration Url</code> `registration-url` for where to direct an user when he tries to
 						register.</p>
@@ -52,7 +52,7 @@
 			<div class="row panel panel-body">
 				<div class="form-group">
 					<label for="logoutURL">Logout redirect URL</label>
-					<input type="text" id="logoutURL" name="logoutURL" title="logoutURL" class="form-control"
+					<input type="url" id="logoutURL" name="logoutURL" title="logoutURL" class="form-control"
 						placeholder="https://example.com/logout">
 					<p><code>Logout Url</code> `logout-url` is the openedx logout url which will be used to clear session when user
 						logs out from nodebb.</p>


### PR DESCRIPTION
When user tries to log into admin login using '/adminLogin' endpoint,
now user is redirected to admin panel. Previoulsy user was redirected to
nodebb home and then had to navigate to admin panel.

Remove "adminlogin" endpoint which was previously added so that admin can login using this endpoint as normal "/login" page was replaced by openedx login page. But now admin can login using the traditional "/admin" endpoint and then redirected to nodebb login page. 

Improve admin template: add styling for admin template of the plugin.